### PR TITLE
Fix: Move fonts.scss to _sass/ directory for Jekyll import paths

### DIFF
--- a/_sass/fonts.scss
+++ b/_sass/fonts.scss
@@ -8,6 +8,6 @@
   font-style: normal;
   font-weight: 400 700;
   font-display: swap;
-  src: url("../fonts/playfair-display-latin.woff2") format('woff2');
+  src: url("../assets/fonts/playfair-display-latin.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -29,6 +29,9 @@ $sub-footer-text-color: $white;
 // Fonts - Self-hosted
 @import 'fonts';
 
+// Components - Fonts
+// Note: The @font-face rules are in _sass/fonts.scss
+
 // Bootstrap
 @import 'bootstrap-variables';
 @import 'bootstrap/bootstrap-reboot';


### PR DESCRIPTION
Jekyll/Sass looks for @import files in _sass/ by default. The fonts.scss
file was in assets/css/ which caused a build error.

- Move assets/css/_fonts.scss to _sass/fonts.scss
- Update @font-face url path to ../assets/fonts/playfair-display-latin.woff2
- Add comment in style.scss for clarity

This fixes the build error: 'File to import not found or unreadable: fonts'

Co-authored-by: salabaz <salabaz@users.noreply.github.com>
